### PR TITLE
Fixed stream stanza attribute separation

### DIFF
--- a/java/de/rwth_aachen/dbis/wsxmppgateway/connection/WsXMPPConnectionHandler.java
+++ b/java/de/rwth_aachen/dbis/wsxmppgateway/connection/WsXMPPConnectionHandler.java
@@ -461,10 +461,10 @@ public class WsXMPPConnectionHandler implements WebSocket, WebSocket.OnFrame, We
 			String xml = "";
 			if (sendXmlHeader)
 				xml += "<?xml version=\"1.0\"?>";
-			xml += "<stream:stream ";
+			xml += "<stream:stream";
 			for (Enumeration<String> e = root.getAttributeNames(); e.hasMoreElements(); ) {
 				String attribute = e.nextElement();
-				xml += attribute + "=\"" + root.getAttribute(attribute) + "\"";
+				xml += " " + attribute + "=\"" + root.getAttribute(attribute) + "\"";
 			}
 			xml +=">";
 			sendMessage(xml);


### PR DESCRIPTION
If stream element had multiple attributes they were not separated.
As a result XML parsing was failing.
